### PR TITLE
Rename plugin to `kubectl-revisions`

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -18,4 +18,4 @@ jobs:
         go-version-file: go.mod
     - run: make verify
     - run: make install
-    - run: kubectl-history --help
+    - run: kubectl-revisions --help

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,7 +18,7 @@ builds:
   mod_timestamp: "{{ .CommitTimestamp }}"
   ldflags:
   - -s -w
-  - -X github.com/timebertt/kubectl-history/pkg/cmd/version.version={{ .Version }}
+  - -X github.com/timebertt/kubectl-revisions/pkg/cmd/version.version={{ .Version }}
 
 archives:
 - format: tar.gz

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,8 +22,7 @@ builds:
 
 archives:
 - format: tar.gz
-  # this name template makes the OS and Arch compatible with the results of uname.
-  name_template: "{{ .ProjectName }}_{{ .Version }}_{{ title.Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+  name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
   # use zip for windows archives
   format_overrides:
   - goos: windows

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -1,41 +1,41 @@
 apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
-  name: history
+  name: revisions
 spec:
   version: {{ .TagName }}
-  homepage: https://github.com/timebertt/kubectl-history
-  shortDescription: Time-travel through your cluster
+  homepage: https://github.com/timebertt/kubectl-revisions
+  shortDescription: Time-travel through your workload's revision history
   description: |
-    Go back in time in the history of rollouts and answers common questions like "Why was my Deployment rolled?"
+    Go back in time in the history of revisions and answers common questions like "Why was my Deployment rolled?"
   platforms:
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    {{addURIAndSha "https://github.com/timebertt/kubectl-history/releases/download/{{ .TagName }}/kubectl-history_{{ .TagName }}_linux_amd64.tar.gz" .TagName }}
-    bin: kubectl-history
+    {{addURIAndSha "https://github.com/timebertt/kubectl-revisions/releases/download/{{ .TagName }}/kubectl-revisions_{{ .TagName }}_linux_amd64.tar.gz" .TagName }}
+    bin: kubectl-revisions
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    {{addURIAndSha "https://github.com/timebertt/kubectl-history/releases/download/{{ .TagName }}/kubectl-history_{{ .TagName }}_linux_arm64.tar.gz" .TagName }}
-    bin: kubectl-history
+    {{addURIAndSha "https://github.com/timebertt/kubectl-revisions/releases/download/{{ .TagName }}/kubectl-revisions_{{ .TagName }}_linux_arm64.tar.gz" .TagName }}
+    bin: kubectl-revisions
   - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    {{addURIAndSha "https://github.com/timebertt/kubectl-history/releases/download/{{ .TagName }}/kubectl-history_{{ .TagName }}_darwin_amd64.tar.gz" .TagName }}
-    bin: kubectl-history
+    {{addURIAndSha "https://github.com/timebertt/kubectl-revisions/releases/download/{{ .TagName }}/kubectl-revisions_{{ .TagName }}_darwin_amd64.tar.gz" .TagName }}
+    bin: kubectl-revisions
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    {{addURIAndSha "https://github.com/timebertt/kubectl-history/releases/download/{{ .TagName }}/kubectl-history_{{ .TagName }}_darwin_arm64.tar.gz" .TagName }}
-    bin: kubectl-history
+    {{addURIAndSha "https://github.com/timebertt/kubectl-revisions/releases/download/{{ .TagName }}/kubectl-revisions_{{ .TagName }}_darwin_arm64.tar.gz" .TagName }}
+    bin: kubectl-revisions
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    {{addURIAndSha "https://github.com/timebertt/kubectl-history/releases/download/{{ .TagName }}/kubectl-history_{{ .TagName }}_windows_amd64.zip" .TagName }}
-    bin: kubectl-history.exe
+    {{addURIAndSha "https://github.com/timebertt/kubectl-revisions/releases/download/{{ .TagName }}/kubectl-revisions_{{ .TagName }}_windows_amd64.zip" .TagName }}
+    bin: kubectl-revisions.exe

--- a/Makefile
+++ b/Makefile
@@ -112,11 +112,11 @@ kind-up kind-down: export KUBECONFIG = $(KIND_KUBECONFIG)
 
 .PHONY: kind-up
 kind-up: $(KIND) $(KUBECTL) ## Launch a kind cluster for local development and testing.
-	$(KIND) create cluster --name history --image kindest/node:$(KIND_KUBERNETES_VERSION)
+	$(KIND) create cluster --name revisions --image kindest/node:$(KIND_KUBERNETES_VERSION)
 	# workaround https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files
 	$(KUBECTL) get nodes -o name | cut -d/ -f2 | xargs -I {} docker exec {} sh -c "sysctl fs.inotify.max_user_instances=8192"
 	# run `export KUBECONFIG=$$PWD/hack/kind_kubeconfig.yaml` to target the created kind cluster.
 
 .PHONY: kind-down
 kind-down: $(KIND) ## Tear down the kind testing cluster.
-	$(KIND) delete cluster --name history
+	$(KIND) delete cluster --name revisions

--- a/Makefile
+++ b/Makefile
@@ -95,11 +95,11 @@ ci-e2e-kind: $(KIND)
 ##@ Build
 
 .PHONY: build
-build: ## Build the kubectl-history binary.
-	go build -o bin/kubectl-history .
+build: ## Build the kubectl-revisions binary.
+	go build -o bin/kubectl-revisions .
 
 .PHONY: install
-install: ## Install the kubectl-history binary to $GOBIN.
+install: ## Install the kubectl-revisions binary to $GOBIN.
 	go install .
 
 ##@ Test Setup

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# kubectl-history
+# kubectl-revisions
 
 🚀 *Time-travel through your cluster* 🕰️
 
 ## About
 
-`kubectl-history` is a [kubectl plugin](https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/) and can be invoked as `kubectl history`, or for short `k history`.
+`kubectl-revisions` is a [kubectl plugin](https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/) and can be invoked as `kubectl revisions`, or for short `k revisions`.
 
-The history plugin allows you to go back in time in the history of rollouts and answers common questions like "Why was my Deployment rolled?"
+The `revisions` plugin allows you to go back in time in the history of revisions and answers common questions like "Why was my Deployment rolled?"
 
 It gives more output than `kubectl rollout history` and is easier to use than `kubectl get replicaset` or `kubectl get controllerrevision`.
 
@@ -18,9 +18,9 @@ go install github.com/timebertt/kubectl-revisions@latest
 
 ## Usage
 
-### `k history get` / `k history list`
+### `k revisions get` / `k revisions list`
 
-Get the rollout history of a workload resource (`Deployment`, `StatefulSet`, or `DaemonSet`).
+Get the revision history of a workload resource (`Deployment`, `StatefulSet`, or `DaemonSet`).
 
 The history is based on the `ReplicaSets`/`ControllerRevisions` still in the system. I.e., the history is limited by the
 configured `revisionHistoryLimit`.
@@ -29,13 +29,13 @@ By default, all revisions are printed as a list. If the `--revision` flag is giv
 instead.
 
 ```bash
-$ k history get deploy nginx -owide
+$ k revisions get deploy nginx -owide
 NAME               REVISION   AGE   CONTAINERS   IMAGES
 nginx-77b4fdf86c   1          22m   nginx        nginx
 nginx-7bf8c77b5b   2          21m   nginx        nginx:latest
 nginx-7bb88f5ff4   3          20m   nginx        nginx:1.24
 
-$ k history get deploy nginx -r -1 -oyaml
+$ k revisions get deploy nginx -r -1 -oyaml
 apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
@@ -46,7 +46,7 @@ metadata:
 This is similar to using `k get replicaset` or `k get controllerrevision`, but allows easy selection of the relevant objects and returns a sorted list.
 This is also similar to `k rollout history`, but doesn't only print revision numbers.
 
-### `k history diff` / `k history why`
+### `k revisions diff` / `k revisions why`
 
 Compare multiple revisions of a workload resource (`Deployment`, `StatefulSet`, or `DaemonSet`).
 A.k.a., "Why was my Deployment rolled?"
@@ -57,7 +57,7 @@ configured `revisionHistoryLimit`.
 By default, the latest two revisions are compared. The `--revision` flag allows selecting the revisions to compare.
 
 ```bash
-$ k history diff deploy nginx
+$ k revisions diff deploy nginx
 comparing revisions 2 and 3 of deployment.apps/nginx
 --- /var/folders/d8/x7ty7dh12sg7vrq374x52pk80000gq/T/deployment.apps_nginx-2577026088/2-nginx-7bf8c77b5b.yaml	2024-05-22 23:16:51
 +++ /var/folders/d8/x7ty7dh12sg7vrq374x52pk80000gq/T/deployment.apps_nginx-2577026088/3-nginx-7bb88f5ff4.yaml	2024-05-22 23:16:51
@@ -72,15 +72,15 @@ comparing revisions 2 and 3 of deployment.apps/nginx
      resources: {}
 ```
 
-The `k history diff` command uses `diff -u -N` to compare revisions by default.
+The `k revisions diff` command uses `diff -u -N` to compare revisions by default.
 It also respects the `KUBECTL_EXTERNAL_DIFF` environment variable like the `kubectl diff` command.
 To get a nicer diff view, you can use one of these:
 
 ```bash
 # Add color to the diff output
-k history diff deploy nginx | colordiff
+k revisions diff deploy nginx | colordiff
 # Specify an external diff programm
-KUBECTL_EXTERNAL_DIFF="colordiff -u" k history diff deploy nginx
+KUBECTL_EXTERNAL_DIFF="colordiff -u" k revisions diff deploy nginx
 # Show diff in VS Code
-KUBECTL_EXTERNAL_DIFF="code --diff --wait" k history diff deploy nginx
+KUBECTL_EXTERNAL_DIFF="code --diff --wait" k revisions diff deploy nginx
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kubectl-revisions
 
-🚀 *Time-travel through your cluster* 🕰️
+🚀 *Time-travel through your workload's revision history* 🕰️
 
 ## About
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It gives more output than `kubectl rollout history` and is easier to use than `k
 ## Installation
 
 ```bash
-go install github.com/timebertt/kubectl-history@latest
+go install github.com/timebertt/kubectl-revisions@latest
 ```
 
 ## Usage

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/timebertt/kubectl-history
+module github.com/timebertt/kubectl-revisions
 
 go 1.22.0
 

--- a/hack/ci-common.sh
+++ b/hack/ci-common.sh
@@ -2,7 +2,7 @@ export_artifacts() {
   [ -n "${ARTIFACTS:-}" ] || return 0
 
   mkdir -p "$ARTIFACTS"
-  cluster_name=history
+  cluster_name=revisions
   echo "> Exporting logs of kind cluster '$cluster_name'"
   kind export logs "$ARTIFACTS" --name "$cluster_name" || true
 

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
-	"github.com/timebertt/kubectl-history/pkg/cmd"
+	"github.com/timebertt/kubectl-revisions/pkg/cmd"
 )
 
 func main() {

--- a/pkg/cmd/diff/diff.go
+++ b/pkg/cmd/diff/diff.go
@@ -68,22 +68,22 @@ with params too, example: KUBECTL_EXTERNAL_DIFF="colordiff -N -u"
  By default, the "diff" command available in your path will be run with the "-u" (unified diff) and "-N" (treat absent
 files as empty) options.`,
 		Example: `  # Find out why the nginx Deployment was rolled: compare the latest two revisions
-  kubectl history diff deploy nginx
+  kubectl revisions diff deploy nginx
   
   # Compare the first and third revision
-  kubectl history diff deploy nginx --revision=1,3
+  kubectl revisions diff deploy nginx --revision=1,3
   
   # Compare the previous revision and the revision before that
-  kubectl history diff deploy nginx --revision=-2
+  kubectl revisions diff deploy nginx --revision=-2
   
   # Add color to the diff output
-  kubectl history diff deploy nginx | colordiff
+  kubectl revisions diff deploy nginx | colordiff
   
   # Specify an external diff programm
-  KUBECTL_EXTERNAL_DIFF="colordiff -u" kubectl history diff deploy nginx
+  KUBECTL_EXTERNAL_DIFF="colordiff -u" kubectl revisions diff deploy nginx
   
   # Show diff in VS Code
-  KUBECTL_EXTERNAL_DIFF="code --diff --wait" kubectl history diff deploy nginx
+  KUBECTL_EXTERNAL_DIFF="code --diff --wait" kubectl revisions diff deploy nginx
 `,
 
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/diff/diff.go
+++ b/pkg/cmd/diff/diff.go
@@ -14,10 +14,10 @@ import (
 	"k8s.io/utils/exec"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/timebertt/kubectl-history/pkg/cmd/util"
-	"github.com/timebertt/kubectl-history/pkg/diff"
-	"github.com/timebertt/kubectl-history/pkg/history"
-	"github.com/timebertt/kubectl-history/pkg/runutil"
+	"github.com/timebertt/kubectl-revisions/pkg/cmd/util"
+	"github.com/timebertt/kubectl-revisions/pkg/diff"
+	"github.com/timebertt/kubectl-revisions/pkg/history"
+	"github.com/timebertt/kubectl-revisions/pkg/runutil"
 )
 
 type Options struct {

--- a/pkg/cmd/get/get.go
+++ b/pkg/cmd/get/get.go
@@ -38,8 +38,8 @@ func NewCommand(f util.Factory, streams genericclioptions.IOStreams) *cobra.Comm
 		Use:     "get (TYPE[.VERSION][.GROUP] NAME | TYPE[.VERSION][.GROUP]/NAME)",
 		Aliases: []string{"list", "ls"},
 
-		Short: "Get the rollout history of a workload resource",
-		Long: `Get the rollout history of a workload resource (Deployment, StatefulSet, or DaemonSet).
+		Short: "Get the revision history of a workload resource",
+		Long: `Get the revision history of a workload resource (Deployment, StatefulSet, or DaemonSet).
 
  The history is based on the ReplicaSets/ControllerRevisions still in the system. I.e., the history is limited by the
 configured revisionHistoryLimit.
@@ -48,13 +48,13 @@ configured revisionHistoryLimit.
 instead.
 `,
 		Example: `  # Get all revisions of the nginx Deployment
-  kubectl history get deploy nginx
+  kubectl revisions get deploy nginx
   
   # Print additional columns like the revisions' images
-  kubectl history get deploy nginx -o wide
+  kubectl revisions get deploy nginx -o wide
   
   # Get the latest revision in YAML
-  kubectl history get deploy nginx --revision=-1 -o yaml`,
+  kubectl revisions get deploy nginx --revision=-1 -o yaml`,
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()

--- a/pkg/cmd/get/get.go
+++ b/pkg/cmd/get/get.go
@@ -10,8 +10,8 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/timebertt/kubectl-history/pkg/cmd/util"
-	"github.com/timebertt/kubectl-history/pkg/history"
+	"github.com/timebertt/kubectl-revisions/pkg/cmd/util"
+	"github.com/timebertt/kubectl-revisions/pkg/history"
 )
 
 type Options struct {

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -9,10 +9,10 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/kubectl/pkg/util/term"
 
-	"github.com/timebertt/kubectl-history/pkg/cmd/diff"
-	"github.com/timebertt/kubectl-history/pkg/cmd/get"
-	"github.com/timebertt/kubectl-history/pkg/cmd/util"
-	"github.com/timebertt/kubectl-history/pkg/cmd/version"
+	"github.com/timebertt/kubectl-revisions/pkg/cmd/diff"
+	"github.com/timebertt/kubectl-revisions/pkg/cmd/get"
+	"github.com/timebertt/kubectl-revisions/pkg/cmd/util"
+	"github.com/timebertt/kubectl-revisions/pkg/cmd/version"
 )
 
 type Options struct {

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -32,7 +32,7 @@ func NewCommand() *cobra.Command {
 	o := NewOptions()
 
 	cmd := &cobra.Command{
-		Use:   "history",
+		Use:   "revisions",
 		Short: "Time-travel through your cluster",
 
 		PersistentPreRunE: func(*cobra.Command, []string) error {
@@ -92,14 +92,14 @@ func NewCommand() *cobra.Command {
 // I.e., the default template would output:
 //
 //	Usage:
-//	  history [command]
+//	  revisions [command]
 //
 // The modified template outputs:
 //
 //	Usage:
-//	  kubectl history [command]
+//	  kubectl revisions [command]
 //
-// Changing cmd.Use to `kubectl history` makes cobra remove `history` from all command paths and use lines.
+// Changing cmd.Use to `kubectl revisions` makes cobra remove `revisions` from all command paths and use lines.
 func customizeUsageTemplate(cmd *cobra.Command) {
 	defaultTmpl := cmd.UsageTemplate()
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -33,7 +33,7 @@ func NewCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "revisions",
-		Short: "Time-travel through your cluster",
+		Short: "Time-travel through your workload's revision history",
 
 		PersistentPreRunE: func(*cobra.Command, []string) error {
 			warningHandler := rest.NewWarningWriter(o.IOStreams.ErrOut, rest.WarningWriterOptions{Deduplicate: true, Color: term.AllowsColorOutput(o.IOStreams.ErrOut)})

--- a/pkg/cmd/util/print_flags.go
+++ b/pkg/cmd/util/print_flags.go
@@ -11,7 +11,7 @@ import (
 	kubectlget "k8s.io/kubectl/pkg/cmd/get"
 	"k8s.io/kubectl/pkg/scheme"
 
-	"github.com/timebertt/kubectl-history/pkg/printer"
+	"github.com/timebertt/kubectl-revisions/pkg/printer"
 )
 
 // PrintFlags composes common output-related flags used in multiple commands.

--- a/pkg/cmd/util/table_flags.go
+++ b/pkg/cmd/util/table_flags.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/utils/pointer"
 
-	"github.com/timebertt/kubectl-history/pkg/printer"
+	"github.com/timebertt/kubectl-revisions/pkg/printer"
 )
 
 type TablePrintFlags struct {

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -9,7 +9,7 @@ import (
 )
 
 // version can be set via:
-// -ldflags="-X 'github.com/timebertt/kubectl-history/pkg/cmd/version.version=$TAG'"
+// -ldflags="-X 'github.com/timebertt/kubectl-revisions/pkg/cmd/version.version=$TAG'"
 // If not overwritten via ldflags, it defaults to the go module's version if installed via `go install`.
 var version string
 
@@ -39,7 +39,7 @@ func NewCommand(streams genericclioptions.IOStreams) *cobra.Command {
 	return &cobra.Command{
 		Use:                   "version",
 		DisableFlagsInUseLine: true,
-		Short:                 "Print the version of kubectl-history",
+		Short:                 "Print the version of kubectl-revisions",
 		Long: `The version command prints the source version that was used to build the binary.
 Note that the version string's format can be different depending on how the binary was built.
 E.g, release builds inject the version via -ldflags, while installing with 'go install' injects
@@ -48,7 +48,7 @@ the go module's version (which can also be "(devel)").`,
 			if version == "" {
 				_, _ = fmt.Fprintln(o.Out, "could not determine build information")
 			} else {
-				_, _ = fmt.Fprintf(o.Out, "kubectl-history %s\n", version)
+				_, _ = fmt.Fprintf(o.Out, "kubectl-revisions %s\n", version)
 			}
 
 			return nil

--- a/pkg/diff/files.go
+++ b/pkg/diff/files.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/timebertt/kubectl-history/pkg/runutil"
+	"github.com/timebertt/kubectl-revisions/pkg/runutil"
 )
 
 // Files is a compound handle for multiple files in a directory that shall be compared using a diff programm.

--- a/pkg/diff/files_test.go
+++ b/pkg/diff/files_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	. "github.com/timebertt/kubectl-history/pkg/diff"
+	. "github.com/timebertt/kubectl-revisions/pkg/diff"
 )
 
 var _ = Describe("Files", func() {

--- a/pkg/history/controllerrevision_test.go
+++ b/pkg/history/controllerrevision_test.go
@@ -7,7 +7,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	. "github.com/timebertt/kubectl-history/pkg/history"
+	. "github.com/timebertt/kubectl-revisions/pkg/history"
 )
 
 var _ = Describe("ControllerRevision", func() {

--- a/pkg/history/daemonset_test.go
+++ b/pkg/history/daemonset_test.go
@@ -14,7 +14,7 @@ import (
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	. "github.com/timebertt/kubectl-history/pkg/history"
+	. "github.com/timebertt/kubectl-revisions/pkg/history"
 )
 
 var _ = Describe("DaemonSetHistory", func() {

--- a/pkg/history/deployment_test.go
+++ b/pkg/history/deployment_test.go
@@ -16,7 +16,7 @@ import (
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	. "github.com/timebertt/kubectl-history/pkg/history"
+	. "github.com/timebertt/kubectl-revisions/pkg/history"
 )
 
 var _ = Describe("DeploymentHistory", func() {

--- a/pkg/history/fake/revision.go
+++ b/pkg/history/fake/revision.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/timebertt/kubectl-history/pkg/history"
+	"github.com/timebertt/kubectl-revisions/pkg/history"
 )
 
 var _ history.Revision = &Revision{}

--- a/pkg/history/history_suite_test.go
+++ b/pkg/history/history_suite_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/onsi/gomega/types"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
-	. "github.com/timebertt/kubectl-history/pkg/history"
+	. "github.com/timebertt/kubectl-revisions/pkg/history"
 )
 
 func TestHistory(t *testing.T) {

--- a/pkg/history/history_test.go
+++ b/pkg/history/history_test.go
@@ -13,8 +13,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	. "github.com/timebertt/kubectl-history/pkg/history"
-	"github.com/timebertt/kubectl-history/pkg/history/fake"
+	. "github.com/timebertt/kubectl-revisions/pkg/history"
+	"github.com/timebertt/kubectl-revisions/pkg/history/fake"
 )
 
 var _ = Describe("History", func() {

--- a/pkg/history/replicaset_test.go
+++ b/pkg/history/replicaset_test.go
@@ -10,7 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	deploymentutil "k8s.io/kubectl/pkg/util/deployment"
 
-	. "github.com/timebertt/kubectl-history/pkg/history"
+	. "github.com/timebertt/kubectl-revisions/pkg/history"
 )
 
 var _ = Describe("ReplicaSet", func() {

--- a/pkg/history/sort_test.go
+++ b/pkg/history/sort_test.go
@@ -4,8 +4,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	. "github.com/timebertt/kubectl-history/pkg/history"
-	"github.com/timebertt/kubectl-history/pkg/history/fake"
+	. "github.com/timebertt/kubectl-revisions/pkg/history"
+	"github.com/timebertt/kubectl-revisions/pkg/history/fake"
 )
 
 var _ = Describe("Sort", func() {

--- a/pkg/history/statefulset_test.go
+++ b/pkg/history/statefulset_test.go
@@ -14,7 +14,7 @@ import (
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	. "github.com/timebertt/kubectl-history/pkg/history"
+	. "github.com/timebertt/kubectl-revisions/pkg/history"
 )
 
 var _ = Describe("StatefulSetHistory", func() {

--- a/pkg/printer/revision.go
+++ b/pkg/printer/revision.go
@@ -10,7 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
-	"github.com/timebertt/kubectl-history/pkg/history"
+	"github.com/timebertt/kubectl-revisions/pkg/history"
 )
 
 var _ printers.ResourcePrinter = RevisionPrinter{}

--- a/pkg/printer/revision_test.go
+++ b/pkg/printer/revision_test.go
@@ -8,8 +8,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/timebertt/kubectl-history/pkg/history"
-	. "github.com/timebertt/kubectl-history/pkg/printer"
+	"github.com/timebertt/kubectl-revisions/pkg/history"
+	. "github.com/timebertt/kubectl-revisions/pkg/printer"
 )
 
 var _ = Describe("RevisionPrinter", func() {

--- a/pkg/printer/table.go
+++ b/pkg/printer/table.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/printers"
 
-	"github.com/timebertt/kubectl-history/pkg/history"
+	"github.com/timebertt/kubectl-revisions/pkg/history"
 )
 
 var _ printers.ResourcePrinter = RevisionsToTablePrinter{}

--- a/pkg/printer/table_test.go
+++ b/pkg/printer/table_test.go
@@ -7,8 +7,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/timebertt/kubectl-history/pkg/history"
-	. "github.com/timebertt/kubectl-history/pkg/printer"
+	"github.com/timebertt/kubectl-revisions/pkg/history"
+	. "github.com/timebertt/kubectl-revisions/pkg/printer"
 )
 
 var _ = Describe("RevisionsToTablePrinter", func() {

--- a/pkg/runutil/runutil_test.go
+++ b/pkg/runutil/runutil_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	. "github.com/timebertt/kubectl-history/pkg/runutil"
+	. "github.com/timebertt/kubectl-revisions/pkg/runutil"
 )
 
 var _ = Describe("CaptureError", func() {

--- a/test/e2e/diff_test.go
+++ b/test/e2e/diff_test.go
@@ -34,7 +34,7 @@ var _ = Describe("diff command", func() {
 
 			workload.BumpImage(object)
 
-			session := RunHistoryAndWait(args...)
+			session := RunPluginAndWait(args...)
 			Eventually(session).Should(Say(`--- \S+\/1-nginx-\S+\s`))
 			Eventually(session).Should(Say(`\+\+\+ \S+\/2-nginx-\S+\s`))
 			Eventually(session).Should(Say(`-.+:0.1\n`))
@@ -47,7 +47,7 @@ var _ = Describe("diff command", func() {
 			workload.BumpImage(object)
 			workload.BumpImage(object)
 
-			session := RunHistoryAndWait(args...)
+			session := RunPluginAndWait(args...)
 			Eventually(session).Should(Say(`--- \S+\/2-nginx-\S+\s`))
 			Eventually(session).Should(Say(`\+\+\+ \S+\/3-nginx-\S+\s`))
 			Eventually(session).Should(Say(`-.+:0.2\n`))
@@ -58,7 +58,7 @@ var _ = Describe("diff command", func() {
 			workload.BumpImage(object)
 			workload.BumpImage(object)
 
-			session := RunHistoryAndWait(append(args, "--revision=1,3")...)
+			session := RunPluginAndWait(append(args, "--revision=1,3")...)
 			Eventually(session).Should(Say(`--- \S+\/1-nginx-\S+\s`))
 			Eventually(session).Should(Say(`\+\+\+ \S+\/3-nginx-\S+\s`))
 			Eventually(session).Should(Say(`-.+:0.1\n`))
@@ -69,7 +69,7 @@ var _ = Describe("diff command", func() {
 			workload.BumpImage(object)
 			workload.BumpImage(object)
 
-			session := RunHistoryAndWait(append(args, "--revision=2")...)
+			session := RunPluginAndWait(append(args, "--revision=2")...)
 			Eventually(session).Should(Say(`--- \S+\/1-nginx-\S+\s`))
 			Eventually(session).Should(Say(`\+\+\+ \S+\/2-nginx-\S+\s`))
 			Eventually(session).Should(Say(`-.+:0.1\n`))
@@ -80,7 +80,7 @@ var _ = Describe("diff command", func() {
 			workload.BumpImage(object)
 			workload.BumpImage(object)
 
-			session := RunHistoryAndWait(append(args, "--revision=-2")...)
+			session := RunPluginAndWait(append(args, "--revision=-2")...)
 			Eventually(session).Should(Say(`--- \S+\/1-nginx-\S+\s`))
 			Eventually(session).Should(Say(`\+\+\+ \S+\/2-nginx-\S+\s`))
 			Eventually(session).Should(Say(`-.+:0.1\n`))
@@ -91,7 +91,7 @@ var _ = Describe("diff command", func() {
 			workload.BumpImage(object)
 			workload.BumpImage(object)
 
-			session := RunHistoryAndWait(append(args, "-o", "jsonpath={.spec.containers[0].image}")...)
+			session := RunPluginAndWait(append(args, "-o", "jsonpath={.spec.containers[0].image}")...)
 			Eventually(session).Should(Say(`--- \S+\/2-nginx-\S+\s`))
 			Eventually(session).Should(Say(`\+\+\+ \S+\/3-nginx-\S+\s`))
 			Eventually(session).Should(Say(`-.+:0.2\n`))
@@ -101,7 +101,7 @@ var _ = Describe("diff command", func() {
 		It("should diff the revisions using the external diff programm", func() {
 			workload.BumpImage(object)
 
-			cmd := NewHistoryCommand(args...)
+			cmd := NewPluginCommand(args...)
 			cmd.Env = append(cmd.Env, "KUBECTL_EXTERNAL_DIFF=cat")
 
 			session := Wait(RunCommand(cmd))
@@ -127,7 +127,7 @@ var _ = Describe("diff command", func() {
 
 			workload.BumpImage(object)
 
-			session := RunHistoryAndWait(args...)
+			session := RunPluginAndWait(args...)
 			Eventually(session).Should(Say(`--- \S+\/1-nginx-\S+\s`))
 			Eventually(session).Should(Say(`\+\+\+ \S+\/2-nginx-\S+\s`))
 			Eventually(session).Should(Say(`-.+:0.1\n`))
@@ -139,7 +139,7 @@ var _ = Describe("diff command", func() {
 
 			workload.BumpImage(object)
 
-			session := RunHistoryAndWait(args...)
+			session := RunPluginAndWait(args...)
 			Eventually(session).Should(Say(`--- \S+\/1-nginx-\S+\s`))
 			Eventually(session).Should(Say(`\+\+\+ \S+\/2-nginx-\S+\s`))
 			Eventually(session).Should(Say(`-.+:0.1\n`))
@@ -151,7 +151,7 @@ var _ = Describe("diff command", func() {
 
 			workload.BumpImage(object)
 
-			session := RunHistoryAndWait(args...)
+			session := RunPluginAndWait(args...)
 			Eventually(session).Should(Say(`--- \S+\/1-nginx-\S+\s`))
 			Eventually(session).Should(Say(`\+\+\+ \S+\/2-nginx-\S+\s`))
 			Eventually(session).Should(Say(`-.+:0.1\n`))
@@ -164,7 +164,7 @@ var _ = Describe("diff command", func() {
 
 			workload.BumpImage(object)
 
-			session := RunHistoryAndWait(args...)
+			session := RunPluginAndWait(args...)
 			Eventually(session).Should(Say(`--- \S+\/1-nginx-\S+\s`))
 			Eventually(session).Should(Say(`\+\+\+ \S+\/2-nginx-\S+\s`))
 			Eventually(session).Should(Say(`-.+:0.1\n`))
@@ -174,7 +174,7 @@ var _ = Describe("diff command", func() {
 		It("should diff the full revision objects on --template-only=false", func() {
 			workload.BumpImage(object)
 
-			cmd := NewHistoryCommand(append(args, "--template-only=false")...)
+			cmd := NewPluginCommand(append(args, "--template-only=false")...)
 			cmd.Env = append(cmd.Env, "KUBECTL_EXTERNAL_DIFF=cat")
 
 			session := Wait(RunCommand(cmd))
@@ -191,7 +191,7 @@ var _ = Describe("diff command", func() {
 		It("should diff the full revision objects on --template-only=false", func() {
 			workload.BumpImage(object)
 
-			cmd := NewHistoryCommand(append(args, "--template-only=false")...)
+			cmd := NewPluginCommand(append(args, "--template-only=false")...)
 			cmd.Env = append(cmd.Env, "KUBECTL_EXTERNAL_DIFF=cat")
 
 			session := Wait(RunCommand(cmd))

--- a/test/e2e/diff_test.go
+++ b/test/e2e/diff_test.go
@@ -6,8 +6,8 @@ import (
 	. "github.com/onsi/gomega/gbytes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	. "github.com/timebertt/kubectl-history/test/e2e/exec"
-	"github.com/timebertt/kubectl-history/test/e2e/workload"
+	. "github.com/timebertt/kubectl-revisions/test/e2e/exec"
+	"github.com/timebertt/kubectl-revisions/test/e2e/workload"
 )
 
 var _ = Describe("diff command", func() {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -18,8 +18,8 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	"github.com/timebertt/kubectl-history/test/e2e/exec"
-	"github.com/timebertt/kubectl-history/test/e2e/workload"
+	"github.com/timebertt/kubectl-revisions/test/e2e/exec"
+	"github.com/timebertt/kubectl-revisions/test/e2e/workload"
 )
 
 func TestMain(m *testing.M) {
@@ -31,7 +31,7 @@ func TestMain(m *testing.M) {
 
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "kubectl-history E2E Test Suite")
+	RunSpecs(t, "kubectl-revisions E2E Test Suite")
 }
 
 var (

--- a/test/e2e/exec/exec.go
+++ b/test/e2e/exec/exec.go
@@ -25,11 +25,11 @@ func PrepareTestBinaries() {
 	if binaryPath != "" {
 		logf.Log.Info("Using pre-built binary", "path", binaryPath)
 	} else {
-		By("Building kubectl-history binary")
+		By("Building kubectl-revisions binary")
 		var err error
 		binaryPath, err = gexec.Build("../..")
 		Expect(err).NotTo(HaveOccurred())
-		binaryPath = filepath.Join(binaryPath, "kubectl-history")
+		binaryPath = filepath.Join(binaryPath, "kubectl-revisions")
 		logf.Log.Info("Using binary", "path", binaryPath)
 
 		DeferCleanup(func() {
@@ -43,7 +43,7 @@ func PrepareTestBinaries() {
 func preparePath() {
 	By("Preparing test PATH")
 	var err error
-	tmpPath, err = os.MkdirTemp("", "e2e-kubectl-history-")
+	tmpPath, err = os.MkdirTemp("", "e2e-kubectl-revisions-")
 	Expect(err).NotTo(HaveOccurred())
 	logf.Log.Info("Using tmp dir as PATH", "dir", tmpPath)
 
@@ -55,10 +55,10 @@ func preparePath() {
 	// Use a single-dir PATH with only the needed binaries inside instead of appending the user's PATH to run against a
 	// clean test environment.
 
-	// symlink the kubectl-history binary so that kubectl can find the plugin
+	// symlink the kubectl-revisions binary so that kubectl can find the plugin
 	absoluteBinaryPath, err := filepath.Abs(binaryPath)
 	Expect(err).NotTo(HaveOccurred())
-	Expect(os.Symlink(absoluteBinaryPath, filepath.Join(tmpPath, "kubectl-history"))).To(Succeed())
+	Expect(os.Symlink(absoluteBinaryPath, filepath.Join(tmpPath, "kubectl-revisions"))).To(Succeed())
 
 	// diff is used as an external diff command
 	diffPath, err := exec.LookPath("diff")

--- a/test/e2e/exec/exec.go
+++ b/test/e2e/exec/exec.go
@@ -71,9 +71,9 @@ func preparePath() {
 	Expect(os.Symlink(catPath, filepath.Join(tmpPath, "cat"))).To(Succeed())
 }
 
-func NewHistoryCommand(args ...string) *exec.Cmd {
+func NewPluginCommand(args ...string) *exec.Cmd {
 	// nolint:gosec // no security risk in shared test code
-	command := exec.Command("kubectl", append([]string{"history"}, args...)...)
+	command := exec.Command("kubectl", append([]string{"revisions"}, args...)...)
 	command.Env = append(command.Environ(), "PATH="+tmpPath)
 
 	return command
@@ -99,10 +99,10 @@ func Wait(session *gexec.Session) *gexec.Session {
 	return session
 }
 
-func RunHistory(args ...string) *gexec.Session {
-	return RunCommand(NewHistoryCommand(args...))
+func RunPlugin(args ...string) *gexec.Session {
+	return RunCommand(NewPluginCommand(args...))
 }
 
-func RunHistoryAndWait(args ...string) *gexec.Session {
-	return Wait(RunHistory(args...))
+func RunPluginAndWait(args ...string) *gexec.Session {
+	return Wait(RunPlugin(args...))
 }

--- a/test/e2e/get_test.go
+++ b/test/e2e/get_test.go
@@ -11,8 +11,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	. "github.com/timebertt/kubectl-history/test/e2e/exec"
-	"github.com/timebertt/kubectl-history/test/e2e/workload"
+	. "github.com/timebertt/kubectl-revisions/test/e2e/exec"
+	"github.com/timebertt/kubectl-revisions/test/e2e/workload"
 )
 
 var _ = Describe("get command", func() {

--- a/test/e2e/get_test.go
+++ b/test/e2e/get_test.go
@@ -36,18 +36,18 @@ var _ = Describe("get command", func() {
 
 		It("should work with alias ls", func() {
 			args[0] = "ls"
-			Eventually(RunHistoryAndWait(args...)).Should(Say(`nginx-\S+\s+1\s+\S+\n`))
+			Eventually(RunPluginAndWait(args...)).Should(Say(`nginx-\S+\s+1\s+\S+\n`))
 		})
 
 		It("should work with alias list", func() {
 			args[0] = "list"
-			Eventually(RunHistoryAndWait(args...)).Should(Say(`nginx-\S+\s+1\s+\S+\n`))
+			Eventually(RunPluginAndWait(args...)).Should(Say(`nginx-\S+\s+1\s+\S+\n`))
 		})
 	})
 
 	testCommon := func() {
 		It("should print a single revision in list format", func() {
-			session := RunHistoryAndWait(args...)
+			session := RunPluginAndWait(args...)
 			Eventually(session).Should(Say(`nginx-\S+\s+1\s+\S+\n`))
 			Consistently(session).ShouldNot(Say(`nginx-`))
 		})
@@ -56,7 +56,7 @@ var _ = Describe("get command", func() {
 			workload.BumpImage(object)
 			workload.BumpImage(object)
 
-			session := RunHistoryAndWait(append(args, "-o", "wide")...)
+			session := RunPluginAndWait(append(args, "-o", "wide")...)
 			Eventually(session).Should(Say(`nginx-\S+\s+1\s+\S+\s+nginx\s+\S+:0.1\n`))
 			Eventually(session).Should(Say(`nginx-\S+\s+2\s+\S+\s+nginx\s+\S+:0.2\n`))
 			Eventually(session).Should(Say(`nginx-\S+\s+3\s+\S+\s+nginx\s+\S+:0.3\n`))
@@ -67,7 +67,7 @@ var _ = Describe("get command", func() {
 			workload.BumpImage(object)
 			workload.BumpImage(object)
 
-			session := RunHistoryAndWait(append(args, "--revision=2")...)
+			session := RunPluginAndWait(append(args, "--revision=2")...)
 			Eventually(session).Should(Say(`nginx-\S+\s+2\s+\S+\n`))
 			Consistently(session).ShouldNot(Say(`nginx-`))
 		})
@@ -76,7 +76,7 @@ var _ = Describe("get command", func() {
 			workload.BumpImage(object)
 			workload.BumpImage(object)
 
-			session := RunHistoryAndWait(append(args, "--revision=2", "-o", "wide")...)
+			session := RunPluginAndWait(append(args, "--revision=2", "-o", "wide")...)
 			Eventually(session).Should(Say(`nginx-\S+\s+2\s+\S+\s+nginx\s+\S+:0.2\n`))
 			Consistently(session).ShouldNot(Say(`nginx-`))
 		})
@@ -85,7 +85,7 @@ var _ = Describe("get command", func() {
 			workload.BumpImage(object)
 			workload.BumpImage(object)
 
-			session := RunHistoryAndWait(append(args, "--revision=1", "-o", "yaml")...)
+			session := RunPluginAndWait(append(args, "--revision=1", "-o", "yaml")...)
 
 			yamlBytes, err := io.ReadAll(session.Out)
 			Expect(err).NotTo(HaveOccurred())
@@ -98,7 +98,7 @@ var _ = Describe("get command", func() {
 			workload.BumpImage(object)
 			workload.BumpImage(object)
 
-			session := RunHistoryAndWait(append(args, "--revision=2", "-o", "json", "--template-only")...)
+			session := RunPluginAndWait(append(args, "--revision=2", "-o", "json", "--template-only")...)
 
 			jsonBytes, err := io.ReadAll(session.Out)
 			Expect(err).NotTo(HaveOccurred())
@@ -113,7 +113,7 @@ var _ = Describe("get command", func() {
 			workload.BumpImage(object)
 			workload.BumpImage(object)
 
-			session := RunHistoryAndWait(append(args, "-o", "yaml")...)
+			session := RunPluginAndWait(append(args, "-o", "yaml")...)
 
 			yamlBytes, err := io.ReadAll(session.Out)
 			Expect(err).NotTo(HaveOccurred())
@@ -136,23 +136,23 @@ var _ = Describe("get command", func() {
 
 		It("should work with short type", func() {
 			args[3] = "deploy"
-			Eventually(RunHistoryAndWait(args...)).Should(Say(`nginx-\S+\s+1\s+\S+\n`))
+			Eventually(RunPluginAndWait(args...)).Should(Say(`nginx-\S+\s+1\s+\S+\n`))
 		})
 
 		It("should work with grouped type", func() {
 			args[3] = "deployments.apps"
-			Eventually(RunHistoryAndWait(args...)).Should(Say(`nginx-\S+\s+1\s+\S+\n`))
+			Eventually(RunPluginAndWait(args...)).Should(Say(`nginx-\S+\s+1\s+\S+\n`))
 		})
 
 		It("should work with fully-qualified type", func() {
 			args[3] = "deployments.v1.apps"
-			Eventually(RunHistoryAndWait(args...)).Should(Say(`nginx-\S+\s+1\s+\S+\n`))
+			Eventually(RunPluginAndWait(args...)).Should(Say(`nginx-\S+\s+1\s+\S+\n`))
 		})
 
 		It("should work with slash name", func() {
 			args[3] = "deployment/nginx"
 			args = args[:len(args)-1]
-			Eventually(RunHistoryAndWait(args...)).Should(Say(`nginx-\S+\s+1\s+\S+\n`))
+			Eventually(RunPluginAndWait(args...)).Should(Say(`nginx-\S+\s+1\s+\S+\n`))
 		})
 	})
 

--- a/test/e2e/help_test.go
+++ b/test/e2e/help_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
 
-	. "github.com/timebertt/kubectl-history/test/e2e/exec"
+	. "github.com/timebertt/kubectl-revisions/test/e2e/exec"
 )
 
 var _ = Describe("command help", func() {

--- a/test/e2e/help_test.go
+++ b/test/e2e/help_test.go
@@ -14,7 +14,7 @@ var _ = Describe("command help", func() {
 		GinkgoHelper()
 
 		Eventually(session).Should(Say(`Usage:`))
-		Eventually(session).Should(Say(`kubectl history \[command\]\n`))
+		Eventually(session).Should(Say(`kubectl revisions \[command\]\n`))
 		Eventually(session).Should(Say(`Available Commands:\n`))
 		Eventually(session).Should(Say(`\s+diff\s+`))
 		Eventually(session).Should(Say(`Other Commands:\n`))
@@ -24,21 +24,21 @@ var _ = Describe("command help", func() {
 
 	Describe("root command", func() {
 		It("should print help without args", func() {
-			expectHelp(RunHistoryAndWait())
+			expectHelp(RunPluginAndWait())
 		})
 
 		It("should print help on -h arg", func() {
-			expectHelp(RunHistoryAndWait("-h"))
+			expectHelp(RunPluginAndWait("-h"))
 		})
 
 		It("should print help on --help arg", func() {
-			expectHelp(RunHistoryAndWait("--help"))
+			expectHelp(RunPluginAndWait("--help"))
 		})
 	})
 
 	Describe("help command", func() {
 		It("should print help", func() {
-			expectHelp(RunHistoryAndWait("help"))
+			expectHelp(RunPluginAndWait("help"))
 		})
 	})
 })

--- a/test/e2e/version_test.go
+++ b/test/e2e/version_test.go
@@ -10,6 +10,6 @@ import (
 
 var _ = Describe("version command", func() {
 	It("should print the version", func() {
-		Eventually(RunHistoryAndWait("version")).Should(Say(`kubectl-revisions \((devel|v.+)\)`))
+		Eventually(RunPluginAndWait("version")).Should(Say(`kubectl-revisions \((devel|v.+)\)`))
 	})
 })

--- a/test/e2e/version_test.go
+++ b/test/e2e/version_test.go
@@ -5,11 +5,11 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gbytes"
 
-	. "github.com/timebertt/kubectl-history/test/e2e/exec"
+	. "github.com/timebertt/kubectl-revisions/test/e2e/exec"
 )
 
 var _ = Describe("version command", func() {
 	It("should print the version", func() {
-		Eventually(RunHistoryAndWait("version")).Should(Say(`kubectl-history \((devel|v.+)\)`))
+		Eventually(RunHistoryAndWait("version")).Should(Say(`kubectl-revisions \((devel|v.+)\)`))
 	})
 })

--- a/test/e2e/workload/namespace.go
+++ b/test/e2e/workload/namespace.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	. "github.com/timebertt/kubectl-history/pkg/test/matcher"
+	. "github.com/timebertt/kubectl-revisions/pkg/test/matcher"
 )
 
 func PrepareTestNamespace() string {
@@ -19,7 +19,7 @@ func PrepareTestNamespace() string {
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "test-",
 			Labels: map[string]string{
-				"e2e-test": "kubectl-history",
+				"e2e-test": "kubectl-revisions",
 			},
 		},
 	}


### PR DESCRIPTION
This PR renames the plugin to `kubectl-revisions` as  the `history` name is already taken in the krew index, see https://github.com/timebertt/kubectl-revisions/issues/16#issuecomment-2134121336.

Part of https://github.com/timebertt/kubectl-revisions/issues/16