### PR TITLE
Add krew installation method

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,4 @@ jobs:
         name: release
         path: dist/*
     - uses: rajatjindal/krew-release-bot@v0.0.46
-      # Skip release bot step on initial plugin release in favor of manual addition.
-      # TODO(timebertt): drop the condition after releasing v0.1.0
-      if: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref != 'refs/tags/v0.1.0' }}
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ It gives more output than `kubectl rollout history` and is easier to use than `k
 
 ## Installation
 
+Using [krew](https://krew.sigs.k8s.io/) (recommended):
+
+```bash
+kubectl krew install revisions
+```
+
+Using go:
+
 ```bash
 go install github.com/timebertt/kubectl-revisions@latest
 ```


### PR DESCRIPTION
This PR enhances the `README` to recommend installing the plugin via krew.
It also activates the krew release automation for future releases.

Fixes https://github.com/timebertt/kubectl-revisions/issues/16

Depends on:
- [x] https://github.com/kubernetes-sigs/krew-index/pull/3863