### PR TITLE
Simplify command help and harmonize with kubectl

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,12 @@ toolchain go1.22.4
 
 require (
 	github.com/go-logr/logr v1.4.2
+	github.com/go-task/slim-sprig/v3 v3.0.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1
 	github.com/spf13/cobra v1.8.0
+	github.com/spf13/pflag v1.0.5
 	k8s.io/api v0.30.1
 	k8s.io/apimachinery v0.30.1
 	k8s.io/cli-runtime v0.30.1
@@ -35,7 +37,6 @@ require (
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect
-	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.0.1 // indirect
@@ -66,7 +67,6 @@ require (
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/pkg/cmd/completion/completion.go
+++ b/pkg/cmd/completion/completion.go
@@ -6,6 +6,8 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+
+	"github.com/timebertt/kubectl-revisions/pkg/cmd/help"
 )
 
 //go:embed kubectl_complete-revisions
@@ -28,6 +30,10 @@ func NewCommand(streams genericiooptions.IOStreams) *cobra.Command {
 		Use:                   "completion",
 		DisableFlagsInUseLine: true,
 
+		Annotations: map[string]string{
+			help.AnnotationHideGlobalFlagsInUsage: "true",
+		},
+
 		Short: "Setup shell completion",
 		Long: `The completion command outputs a script which makes the revisions plugin's completion available to kubectl's completion
 (supported in kubectl v1.26+), see https://github.com/kubernetes/kubernetes/pull/105867 and
@@ -36,10 +42,14 @@ https://github.com/kubernetes/sample-cli-plugin#shell-completion.
 This script needs to be installed as an executable file in PATH named kubectl_complete-revisions. E.g., you could
 install it in krew's binary directory. This is not supported natively yet, but can be done manually as follows
 (see https://github.com/kubernetes-sigs/krew/issues/812):
-  SCRIPT="${KREW_ROOT:-$HOME/.krew}/bin/kubectl_complete-revisions"; kubectl revisions completion > "$SCRIPT" && chmod +x "$SCRIPT"
+` + "```" + `
+SCRIPT="${KREW_ROOT:-$HOME/.krew}/bin/kubectl_complete-revisions"; kubectl revisions completion > "$SCRIPT" && chmod +x "$SCRIPT"
+` + "```" + `
 
 If you don't use krew, you can install the script next to the binary itself as follows:
-  SCRIPT="$(dirname "$(which kubectl-revisions)")/kubectl_complete-revisions"; kubectl revisions completion > "$SCRIPT" && chmod +x "$SCRIPT"
+` + "```" + `
+SCRIPT="$(dirname "$(which kubectl-revisions)")/kubectl_complete-revisions"; kubectl revisions completion > "$SCRIPT" && chmod +x "$SCRIPT"
+` + "```" + `
 
 Alternatively, you can also use https://github.com/marckhouzam/kubectl-plugin_completion to generate completion
 scripts for this plugin along with other kubectl plugins that support it.

--- a/pkg/cmd/diff/diff.go
+++ b/pkg/cmd/diff/diff.go
@@ -56,35 +56,36 @@ func NewCommand(f util.Factory, streams genericiooptions.IOStreams) *cobra.Comma
 
 		Short: "Compare multiple revisions of a workload resource",
 		Long: `Compare multiple revisions of a workload resource (Deployment, StatefulSet, or DaemonSet).
-  A.k.a., "Why was my Deployment rolled?"
+A.k.a., "Why was my Deployment rolled?"
 
- The history is based on the ReplicaSets/ControllerRevisions still in the system. I.e., the history is limited by the
+The history is based on the ReplicaSets/ControllerRevisions still in the system. I.e., the history is limited by the
 configured revisionHistoryLimit.
 
- By default, the latest two revisions are compared. The --revision flag allows selecting the revisions to compare.
+By default, the latest two revisions are compared. The --revision flag allows selecting the revisions to compare.
 
- KUBECTL_EXTERNAL_DIFF environment variable can be used to select your own diff command. Users can use external commands
-with params too, example: KUBECTL_EXTERNAL_DIFF="colordiff -N -u"
+The ` + "`" + `KUBECTL_EXTERNAL_DIFF` + "`" + ` environment variable can be used to select your own diff command. Users can use external
+commands with params too, e.g.: ` + "`" + `KUBECTL_EXTERNAL_DIFF="colordiff -N -u"` + "`" + `
 
- By default, the "diff" command available in your path will be run with the "-u" (unified diff) and "-N" (treat absent
+By default, the ` + "`" + `diff` + "`" + ` command available in your path will be run with the ` + "`" + `-u` + "`" + ` (unified diff) and ` + "`" + `-N` + "`" + ` (treat absent
 files as empty) options.`,
-		Example: `  # Find out why the nginx Deployment was rolled: compare the latest two revisions
-  kubectl revisions diff deploy nginx
-  
-  # Compare the first and third revision
-  kubectl revisions diff deploy nginx --revision=1,3
-  
-  # Compare the previous revision and the revision before that
-  kubectl revisions diff deploy nginx --revision=-2
-  
-  # Use a colored external diff program
-  KUBECTL_EXTERNAL_DIFF="colordiff -u" kubectl revisions diff deploy nginx
-  
-  # Use dyff as a rich diff program
-  KUBECTL_EXTERNAL_DIFF="dyff between --omit-header" kubectl revisions diff deploy nginx
-  
-  # Show diff in VS Code
-  KUBECTL_EXTERNAL_DIFF="code --diff --wait" kubectl revisions diff deploy nginx
+
+		Example: `# Find out why the nginx Deployment was rolled: compare the latest two revisions
+kubectl revisions diff deploy nginx
+
+# Compare the first and third revision
+kubectl revisions diff deploy nginx --revision=1,3
+
+# Compare the previous revision and the revision before that
+kubectl revisions diff deploy nginx --revision=-2
+
+# Use a colored external diff program
+KUBECTL_EXTERNAL_DIFF="colordiff -u" kubectl revisions diff deploy nginx
+
+# Use dyff as a rich diff program
+KUBECTL_EXTERNAL_DIFF="dyff between --omit-header" kubectl revisions diff deploy nginx
+
+# Show diff in VS Code
+KUBECTL_EXTERNAL_DIFF="code --diff --wait" kubectl revisions diff deploy nginx
 `,
 
 		ValidArgsFunction: utilcomp.SpecifiedResourceTypeAndNameNoRepeatCompletionFunc(f, util.Map(history.SupportedKinds, strings.ToLower)),

--- a/pkg/cmd/get/get.go
+++ b/pkg/cmd/get/get.go
@@ -42,20 +42,22 @@ func NewCommand(f util.Factory, streams genericiooptions.IOStreams) *cobra.Comma
 		Short: "Get the revision history of a workload resource",
 		Long: `Get the revision history of a workload resource (Deployment, StatefulSet, or DaemonSet).
 
- The history is based on the ReplicaSets/ControllerRevisions still in the system. I.e., the history is limited by the
+The history is based on the ReplicaSets/ControllerRevisions still in the system. I.e., the history is limited by the
 configured revisionHistoryLimit.
 
- By default, all revisions are printed as a list. If the --revision flag is given, the selected revision is printed
+By default, all revisions are printed as a list. If the --revision flag is given, the selected revision is printed
 instead.
 `,
-		Example: `  # Get all revisions of the nginx Deployment
-  kubectl revisions get deploy nginx
-  
-  # Print additional columns like the revisions' images
-  kubectl revisions get deploy nginx -o wide
-  
-  # Get the latest revision in YAML
-  kubectl revisions get deploy nginx --revision=-1 -o yaml`,
+
+		Example: `# Get all revisions of the nginx Deployment
+kubectl revisions get deploy nginx
+
+# Print additional columns like the revisions' images
+kubectl revisions get deploy nginx -o wide
+
+# Get the latest revision in YAML
+kubectl revisions get deploy nginx --revision=-1 -o yaml
+`,
 
 		ValidArgsFunction: utilcomp.SpecifiedResourceTypeAndNameNoRepeatCompletionFunc(f, util.Map(history.SupportedKinds, strings.ToLower)),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/help/templates.go
+++ b/pkg/cmd/help/templates.go
@@ -1,0 +1,117 @@
+package help
+
+import (
+	"bytes"
+
+	sprig "github.com/go-task/slim-sprig/v3"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"k8s.io/kubectl/pkg/util/templates"
+	"k8s.io/kubectl/pkg/util/term"
+)
+
+const (
+	// AnnotationHideFlagsInUsage is an annotation on a cobra command that causes flags to be hidden in the command help.
+	AnnotationHideFlagsInUsage = "annotation_command_hide_global_flags"
+	// AnnotationHideGlobalFlagsInUsage is an annotation on a cobra command that causes inherited flags to be hidden in
+	// the command help.
+	AnnotationHideGlobalFlagsInUsage = "annotation_command_hide_global_flags"
+)
+
+var (
+	customHelpTemplate = `{{ with (or .Long .Short) -}}
+Synopsis:
+{{ . | trimTrailingWhitespaces | indent 2 }}
+{{- end -}}
+{{- if or .Runnable .HasSubCommands -}}
+{{ .UsageString | trimTrailingWhitespaces}}
+{{- end }}
+`
+
+	customUsageTemplate = `{{if .HasExample }}
+
+Examples:
+{{.Example | trim | indent 2}}
+{{- end}}
+
+{{- if .HasAvailableSubCommands}}
+{{- $cmds := .Commands}}
+{{- if eq (len .Groups) 0}}
+Available Commands:
+{{- range $cmds}}
+	{{- if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}
+	{{- end}}
+{{- end}}
+{{- else}}
+{{- range $group := .Groups}}
+
+{{.Title}}{{range $cmds}}{{if (and (eq .GroupID $group.ID) (or .IsAvailableCommand (eq .Name "help")))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if not .AllChildCommandsHaveGroup}}
+
+Additional Commands:{{range $cmds}}{{if (and (eq .GroupID "") (or .IsAvailableCommand (eq .Name "help")))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}
+
+{{- if and .HasAvailableLocalFlags (not .Annotations.` + AnnotationHideFlagsInUsage + `)}}
+
+Flags:
+{{ flagsUsages .LocalFlags | trimTrailingWhitespaces}}
+{{- end}}
+
+{{- if .HasHelpSubCommands}}
+
+Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}
+{{- end}}
+
+{{- if gt (len .Aliases) 0}}
+
+Aliases:
+  {{.NameAndAliases}}
+{{- end}}
+
+Usage:
+{{- if .Runnable}}
+  {{.UseLine}}
+{{ end}}
+{{- if .HasAvailableSubCommands}}
+  {{.CommandPath}} [command]
+{{ end}}
+
+{{- if .HasAvailableSubCommands}}
+Use "{{.CommandPath}} [command] --help" for more information about a command.
+{{- end}}
+{{- if and .HasAvailableInheritedFlags (not .Annotations.` + AnnotationHideGlobalFlagsInUsage + `)}}
+Use "kubectl revisions options" for a list of global command-line options (applies to all commands).
+{{- end}}
+`
+)
+
+// CustomizeTemplates customizes the help and usage templates of the command.
+func CustomizeTemplates(cmd *cobra.Command) {
+	// add more helpful template funcs like `indent`
+	cobra.AddTemplateFuncs(sprig.HermeticTxtFuncMap())
+	cobra.AddTemplateFunc("flagsUsages", flagsUsages)
+
+	cmd.SetHelpTemplate(customHelpTemplate)
+	cmd.SetUsageTemplate(customUsageTemplate)
+}
+
+// flagsUsages will print out the kubectl help flags
+func flagsUsages(fs *pflag.FlagSet) (string, error) {
+	flagBuf := new(bytes.Buffer)
+	wrapLimit, err := term.GetWordWrapperLimit()
+	if err != nil {
+		wrapLimit = 0
+	}
+	printer := templates.NewHelpFlagPrinter(flagBuf, wrapLimit)
+
+	fs.VisitAll(func(flag *pflag.Flag) {
+		if flag.Hidden {
+			return
+		}
+		printer.PrintHelpFlag(flag)
+	})
+
+	return flagBuf.String(), nil
+}

--- a/pkg/cmd/options/options.go
+++ b/pkg/cmd/options/options.go
@@ -1,0 +1,33 @@
+package options
+
+import (
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+func NewCommand(streams genericiooptions.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "options",
+		DisableFlagsInUseLine: true,
+
+		Short: "Print the list of flags inherited by all commands",
+		Long:  "Print the list of flags inherited by all commands",
+
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(cmd.Usage())
+		},
+	}
+
+	// The `options` command needs write its output to the `out` stream
+	// (typically stdout). Without calling SetOutput here, the Usage()
+	// function call will fall back to stderr.
+	//
+	// See https://github.com/kubernetes/kubernetes/pull/46394 for details.
+	cmd.SetOut(streams.Out)
+	cmd.SetErr(streams.Out)
+
+	templates.UseOptionsTemplates(cmd)
+	return cmd
+}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -15,6 +15,7 @@ import (
 	"github.com/timebertt/kubectl-revisions/pkg/cmd/diff"
 	"github.com/timebertt/kubectl-revisions/pkg/cmd/get"
 	"github.com/timebertt/kubectl-revisions/pkg/cmd/help"
+	"github.com/timebertt/kubectl-revisions/pkg/cmd/options"
 	"github.com/timebertt/kubectl-revisions/pkg/cmd/util"
 	"github.com/timebertt/kubectl-revisions/pkg/cmd/version"
 )
@@ -68,6 +69,7 @@ func NewCommand() *cobra.Command {
 
 	cobra.EnableCommandSorting = false
 
+	// default group
 	defaultGroup := &cobra.Group{
 		ID:    "default",
 		Title: "Available Commands:",
@@ -82,12 +84,12 @@ func NewCommand() *cobra.Command {
 		cmd.AddCommand(subcommand)
 	}
 
+	// other group
 	otherGroup := &cobra.Group{
 		ID:    "other",
 		Title: "Other Commands:",
 	}
 	cmd.AddGroup(otherGroup)
-	cmd.SetHelpCommandGroupID(otherGroup.ID)
 
 	for _, subcommand := range []*cobra.Command{
 		completion.NewCommand(o.IOStreams),
@@ -97,8 +99,21 @@ func NewCommand() *cobra.Command {
 		cmd.AddCommand(subcommand)
 	}
 
+	// help group
+	helpGroup := &cobra.Group{
+		ID:    "help",
+		Title: "Help Commands:",
+	}
+	cmd.AddGroup(helpGroup)
+	cmd.SetHelpCommandGroupID(helpGroup.ID)
+
+	optionsCommand := options.NewCommand(o.IOStreams)
+	optionsCommand.GroupID = helpGroup.ID
+	cmd.AddCommand(optionsCommand)
+
 	help.CustomizeTemplates(cmd)
 
+	// completion
 	utilcomp.SetFactoryForCompletion(f)
 	registerCompletionFuncForGlobalFlags(cmd, f)
 

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/timebertt/kubectl-revisions/pkg/cmd/help"
 )
 
 // version can be set via:
@@ -39,7 +41,12 @@ func NewCommand(streams genericiooptions.IOStreams) *cobra.Command {
 	return &cobra.Command{
 		Use:                   "version",
 		DisableFlagsInUseLine: true,
-		Short:                 "Print the version of kubectl-revisions",
+
+		Annotations: map[string]string{
+			help.AnnotationHideGlobalFlagsInUsage: "true",
+		},
+
+		Short: "Print the version of kubectl-revisions",
 		Long: `The version command prints the source version that was used to build the binary.
 Note that the version string's format can be different depending on how the binary was built.
 E.g, release builds inject the version via -ldflags, while installing with 'go install' injects

--- a/test/e2e/help_test.go
+++ b/test/e2e/help_test.go
@@ -13,13 +13,18 @@ var _ = Describe("command help", func() {
 	expectHelp := func(session *gexec.Session) {
 		GinkgoHelper()
 
-		Eventually(session).Should(Say(`Usage:`))
-		Eventually(session).Should(Say(`kubectl revisions \[command\]\n`))
+		Eventually(session).Should(Say(`Synopsis:\n`))
 		Eventually(session).Should(Say(`Available Commands:\n`))
+		Eventually(session).Should(Say(`\s+get\s+`))
 		Eventually(session).Should(Say(`\s+diff\s+`))
 		Eventually(session).Should(Say(`Other Commands:\n`))
-		Eventually(session).Should(Say(`\s+help\s+`))
+		Eventually(session).Should(Say(`\s+completion\s+`))
 		Eventually(session).Should(Say(`\s+version\s+`))
+		Eventually(session).Should(Say(`Help Commands:\n`))
+		Eventually(session).Should(Say(`\s+options\s+`))
+		Eventually(session).Should(Say(`\s+help\s+`))
+		Eventually(session).Should(Say(`Usage:`))
+		Eventually(session).Should(Say(`kubectl revisions \[command\]\n`))
 	}
 
 	Describe("root command", func() {
@@ -39,6 +44,15 @@ var _ = Describe("command help", func() {
 	Describe("help command", func() {
 		It("should print help", func() {
 			expectHelp(RunPluginAndWait("help"))
+		})
+	})
+
+	Describe("options command", func() {
+		It("should print global flags usage", func() {
+			session := RunPluginAndWait("options")
+
+			Eventually(session).Should(Say(`\s+--cluster='':\n`))
+			Eventually(session).Should(Say(`\s+-n, --namespace='':\n`))
 		})
 	})
 })


### PR DESCRIPTION
This PR simplifies the plugin's command help and harmonizes it with kubectl
- use cobra's display name annotation to replace `revisions` with `kubectl revisions` in the use line (instead of using a custom usage template)
- use custom templates instead of manipulating cobra's default help and usage templates
- add a `kubectl revisions options` command to display help on the global flags, omit them from individual commands' help