### PR TITLE
Reduce the number of `GET` requests

### DIFF
--- a/pkg/cmd/diff/diff.go
+++ b/pkg/cmd/diff/diff.go
@@ -160,12 +160,7 @@ func (o *Options) Run(ctx context.Context, f util.Factory, args []string) (err e
 	kindString := fmt.Sprintf("%s.%s", strings.ToLower(groupKind.Kind), groupKind.Group)
 
 	// get all revisions for the given object
-	hist, err := history.ForGroupKind(c, groupKind)
-	if err != nil {
-		return err
-	}
-
-	revs, err := hist.ListRevisions(ctx, info.Object.(client.Object))
+	revs, err := history.ListRevisions(ctx, c, info.Object.(client.Object))
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/diff/diff.go
+++ b/pkg/cmd/diff/diff.go
@@ -136,7 +136,7 @@ func (o *Options) Validate() error {
 // Run performs the diff operation.
 func (o *Options) Run(ctx context.Context, f util.Factory, args []string) (err error) {
 	r := f.NewBuilder().
-		Unstructured().
+		WithScheme(history.Scheme, history.DecodingVersions...).
 		NamespaceParam(o.Namespace).DefaultNamespace().
 		ResourceTypeOrNameArgs(true, args...).
 		SingleResourceType().
@@ -165,7 +165,7 @@ func (o *Options) Run(ctx context.Context, f util.Factory, args []string) (err e
 		return err
 	}
 
-	revs, err := hist.ListRevisions(ctx, client.ObjectKey{Namespace: info.Namespace, Name: info.Name})
+	revs, err := hist.ListRevisions(ctx, info.Object.(client.Object))
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/get/get.go
+++ b/pkg/cmd/get/get.go
@@ -99,7 +99,7 @@ func (o *Options) Validate() error {
 // Run performs the get operation.
 func (o *Options) Run(ctx context.Context, f util.Factory, args []string) (err error) {
 	r := f.NewBuilder().
-		Unstructured().
+		WithScheme(history.Scheme, history.DecodingVersions...).
 		NamespaceParam(o.Namespace).DefaultNamespace().AllNamespaces(o.AllNamespaces).
 		LabelSelectorParam(o.LabelSelector).
 		RequestChunksOf(o.ChunkSize).
@@ -156,7 +156,7 @@ func (o *Options) Run(ctx context.Context, f util.Factory, args []string) (err e
 	var allRevisions history.Revisions
 	for _, info := range infos {
 		// get all revisions for the given object
-		revs, err := hist.ListRevisions(ctx, client.ObjectKey{Namespace: info.Namespace, Name: info.Name})
+		revs, err := hist.ListRevisions(ctx, info.Object.(client.Object))
 		if err != nil {
 			return err
 		}

--- a/pkg/history/daemonset.go
+++ b/pkg/history/daemonset.go
@@ -17,7 +17,7 @@ var _ History = DaemonSetHistory{}
 
 // DaemonSetHistory implements the History interface for DaemonSets.
 type DaemonSetHistory struct {
-	Client client.Client
+	Client client.Reader
 }
 
 func (d DaemonSetHistory) ListRevisions(ctx context.Context, key client.ObjectKey) (Revisions, error) {

--- a/pkg/history/daemonset.go
+++ b/pkg/history/daemonset.go
@@ -20,10 +20,10 @@ type DaemonSetHistory struct {
 	Client client.Reader
 }
 
-func (d DaemonSetHistory) ListRevisions(ctx context.Context, key client.ObjectKey) (Revisions, error) {
-	daemonSet := &appsv1.DaemonSet{}
-	if err := d.Client.Get(ctx, key, daemonSet); err != nil {
-		return nil, err
+func (d DaemonSetHistory) ListRevisions(ctx context.Context, obj client.Object) (Revisions, error) {
+	daemonSet, ok := obj.(*appsv1.DaemonSet)
+	if !ok {
+		return nil, fmt.Errorf("expected *appsv1.DaemonSet, got %T", obj)
 	}
 
 	controllerRevisionList, podList, err := ListControllerRevisionsAndPods(ctx, d.Client, daemonSet.Namespace, daemonSet.Spec.Selector)

--- a/pkg/history/daemonset_test.go
+++ b/pkg/history/daemonset_test.go
@@ -150,6 +150,15 @@ var _ = Describe("DaemonSetHistory", func() {
 			Expect(revs[1].CurrentReplicas()).To(BeEquivalentTo(1))
 			Expect(revs[1].ReadyReplicas()).To(BeEquivalentTo(1))
 		})
+
+		It("should also work via ListRevisions shortcut", func() {
+			revs, err := ListRevisions(ctx, fakeClient, daemonSet)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(revs).To(HaveLen(2))
+
+			Expect(revs[0].Object()).To(Equal(controllerRevision1))
+			Expect(revs[1].Object()).To(Equal(controllerRevision3))
+		})
 	})
 
 	Describe("NewControllerRevisionForDaemonSet", func() {

--- a/pkg/history/daemonset_test.go
+++ b/pkg/history/daemonset_test.go
@@ -105,19 +105,13 @@ var _ = Describe("DaemonSetHistory", func() {
 			}
 		})
 
-		It("should fail if the DaemonSet doesn't exist", func() {
-			revs, err := history.ListRevisions(ctx, client.ObjectKey{Name: "non-existing"})
-			Expect(err).To(beNotFoundError())
-			Expect(revs).To(BeNil())
-		})
-
 		It("should return an empty list if there are no ControllerRevisions", func() {
 			daemonSet.ResourceVersion = ""
 			daemonSet.UID = ""
 			daemonSet.Namespace = "other"
 			Expect(fakeClient.Create(ctx, daemonSet)).To(Succeed())
 
-			revs, err := history.ListRevisions(ctx, client.ObjectKeyFromObject(daemonSet))
+			revs, err := history.ListRevisions(ctx, daemonSet)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(revs).To(BeEmpty())
 		})
@@ -142,7 +136,7 @@ var _ = Describe("DaemonSetHistory", func() {
 			helper.SetPodCondition(pod, corev1.PodReady, corev1.ConditionTrue)
 			Expect(fakeClient.Create(context.Background(), pod)).To(Succeed())
 
-			revs, err := history.ListRevisions(ctx, client.ObjectKeyFromObject(daemonSet))
+			revs, err := history.ListRevisions(ctx, daemonSet)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(revs).To(HaveLen(2))
 

--- a/pkg/history/deployment.go
+++ b/pkg/history/deployment.go
@@ -13,7 +13,7 @@ var _ History = DeploymentHistory{}
 
 // DeploymentHistory implements the History interface for Deployments.
 type DeploymentHistory struct {
-	Client client.Client
+	Client client.Reader
 }
 
 func (d DeploymentHistory) ListRevisions(ctx context.Context, key client.ObjectKey) (Revisions, error) {

--- a/pkg/history/deployment.go
+++ b/pkg/history/deployment.go
@@ -16,10 +16,10 @@ type DeploymentHistory struct {
 	Client client.Reader
 }
 
-func (d DeploymentHistory) ListRevisions(ctx context.Context, key client.ObjectKey) (Revisions, error) {
-	deployment := &appsv1.Deployment{}
-	if err := d.Client.Get(ctx, key, deployment); err != nil {
-		return nil, err
+func (d DeploymentHistory) ListRevisions(ctx context.Context, obj client.Object) (Revisions, error) {
+	deployment, ok := obj.(*appsv1.Deployment)
+	if !ok {
+		return nil, fmt.Errorf("expected *appsv1.Deployment, got %T", obj)
 	}
 
 	selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)

--- a/pkg/history/deployment_test.go
+++ b/pkg/history/deployment_test.go
@@ -138,6 +138,15 @@ var _ = Describe("DeploymentHistory", func() {
 			Expect(revs[1].CurrentReplicas()).To(BeEquivalentTo(1))
 			Expect(revs[1].ReadyReplicas()).To(BeEquivalentTo(0))
 		})
+
+		It("should also work via ListRevisions shortcut", func() {
+			revs, err := ListRevisions(ctx, fakeClient, deployment)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(revs).To(HaveLen(2))
+
+			Expect(revs[0].Object()).To(Equal(replicaSet1))
+			Expect(revs[1].Object()).To(Equal(replicaSet3))
+		})
 	})
 })
 

--- a/pkg/history/deployment_test.go
+++ b/pkg/history/deployment_test.go
@@ -112,25 +112,19 @@ var _ = Describe("DeploymentHistory", func() {
 			Expect(fakeClient.Create(ctx, replicaSetUnrelated)).To(Succeed())
 		})
 
-		It("should fail if the Deployment doesn't exist", func() {
-			revs, err := history.ListRevisions(ctx, client.ObjectKey{Name: "non-existing"})
-			Expect(err).To(beNotFoundError())
-			Expect(revs).To(BeNil())
-		})
-
 		It("should return an empty list if there are no ReplicaSets", func() {
 			deployment.ResourceVersion = ""
 			deployment.UID = ""
 			deployment.Namespace = "other"
 			Expect(fakeClient.Create(ctx, deployment)).To(Succeed())
 
-			revs, err := history.ListRevisions(ctx, client.ObjectKeyFromObject(deployment))
+			revs, err := history.ListRevisions(ctx, deployment)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(revs).To(BeEmpty())
 		})
 
 		It("should return a sorted list of the owned ReplicaSets", func() {
-			revs, err := history.ListRevisions(ctx, client.ObjectKeyFromObject(deployment))
+			revs, err := history.ListRevisions(ctx, deployment)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(revs).To(HaveLen(2))
 

--- a/pkg/history/history.go
+++ b/pkg/history/history.go
@@ -21,8 +21,8 @@ var SupportedKinds = []string{"Deployment", "StatefulSet", "DaemonSet"}
 // History is a kind-specific client that knows how to access the revision history of objects of that kind.
 // Instantiate a History with For or ForGroupKind.
 type History interface {
-	// ListRevisions returns a sorted revision history (ascending) of the object identified by the given key.
-	ListRevisions(ctx context.Context, key client.ObjectKey) (Revisions, error)
+	// ListRevisions returns a sorted revision history (ascending) of the given object.
+	ListRevisions(ctx context.Context, obj client.Object) (Revisions, error)
 }
 
 // For instantiates a new History client for the given Object.

--- a/pkg/history/history.go
+++ b/pkg/history/history.go
@@ -18,8 +18,20 @@ import (
 // SupportedKinds is a list of object kinds supported by this package.
 var SupportedKinds = []string{"Deployment", "StatefulSet", "DaemonSet"}
 
+// ListRevisions returns a sorted revision history (ascending) of the given object.
+// This is a convenient shortcut for using For and calling History.ListRevisions.
+func ListRevisions(ctx context.Context, c client.Client, obj client.Object) (Revisions, error) {
+	history, err := For(c, obj)
+	if err != nil {
+		return nil, err
+	}
+
+	return history.ListRevisions(ctx, obj)
+}
+
 // History is a kind-specific client that knows how to access the revision history of objects of that kind.
 // Instantiate a History with For or ForGroupKind.
+// Alternatively, use ListRevisions as a shortcut for listing revisions of a single object.
 type History interface {
 	// ListRevisions returns a sorted revision history (ascending) of the given object.
 	ListRevisions(ctx context.Context, obj client.Object) (Revisions, error)

--- a/pkg/history/history.go
+++ b/pkg/history/history.go
@@ -26,6 +26,15 @@ type History interface {
 }
 
 // For instantiates a new History client for the given Object.
+// Note that the object is only used to determine the GroupKind to pass to ForGroupKind. The object for which to list
+// revisions must be passed to History.ListRevisions.
+// I.e., the following
+//
+//	history.For(c, &appsv1.Deployment{})
+//
+// is a convenient shortcut for
+//
+//	history.ForGroupKind(c, appsv1.SchemeGroupVersion.WithKind("Deployment").GroupKind())
 func For(c client.Client, obj client.Object) (History, error) {
 	gvk, err := apiutil.GVKForObject(obj, c.Scheme())
 	if err != nil {
@@ -36,7 +45,7 @@ func For(c client.Client, obj client.Object) (History, error) {
 }
 
 // ForGroupKind instantiates a new History client for the given GroupKind.
-func ForGroupKind(c client.Client, gk schema.GroupKind) (History, error) {
+func ForGroupKind(c client.Reader, gk schema.GroupKind) (History, error) {
 	switch {
 	case gk.Group == appsv1.GroupName && gk.Kind == "DaemonSet":
 		return DaemonSetHistory{Client: c}, nil

--- a/pkg/history/history_suite_test.go
+++ b/pkg/history/history_suite_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gcustom"
 	"github.com/onsi/gomega/types"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	. "github.com/timebertt/kubectl-revisions/pkg/history"
 )
@@ -35,10 +34,4 @@ func copyMap[K comparable, V any](in map[K]V) map[K]V {
 	}
 
 	return out
-}
-
-func beNotFoundError() types.GomegaMatcher {
-	return gcustom.MakeMatcher(func(err error) (bool, error) {
-		return apierrors.IsNotFound(err), nil
-	}).WithMessage("be NotFound error")
 }

--- a/pkg/history/scheme.go
+++ b/pkg/history/scheme.go
@@ -1,0 +1,31 @@
+package history
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+// Scheme is a *runtime.Scheme including all types necessary to handle history-related objects.
+var Scheme = runtime.NewScheme()
+var localSchemeBuilder = runtime.SchemeBuilder{
+	corev1.AddToScheme,
+	appsv1.AddToScheme,
+}
+
+// DecodingVersions is a list of GroupVersions that need to be decoded for handling history-related objects.
+var DecodingVersions = []schema.GroupVersion{
+	corev1.SchemeGroupVersion,
+	appsv1.SchemeGroupVersion,
+}
+
+// AddToScheme adds all types necessary to handle history-related objects to the given scheme.
+var AddToScheme = localSchemeBuilder.AddToScheme
+
+func init() {
+	metav1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
+	utilruntime.Must(AddToScheme(Scheme))
+}

--- a/pkg/history/statefulset.go
+++ b/pkg/history/statefulset.go
@@ -17,7 +17,7 @@ var _ History = StatefulSetHistory{}
 
 // StatefulSetHistory implements the History interface for StatefulSets.
 type StatefulSetHistory struct {
-	Client client.Client
+	Client client.Reader
 }
 
 func (d StatefulSetHistory) ListRevisions(ctx context.Context, key client.ObjectKey) (Revisions, error) {

--- a/pkg/history/statefulset.go
+++ b/pkg/history/statefulset.go
@@ -20,10 +20,10 @@ type StatefulSetHistory struct {
 	Client client.Reader
 }
 
-func (d StatefulSetHistory) ListRevisions(ctx context.Context, key client.ObjectKey) (Revisions, error) {
-	statefulSet := &appsv1.StatefulSet{}
-	if err := d.Client.Get(ctx, key, statefulSet); err != nil {
-		return nil, err
+func (d StatefulSetHistory) ListRevisions(ctx context.Context, obj client.Object) (Revisions, error) {
+	statefulSet, ok := obj.(*appsv1.StatefulSet)
+	if !ok {
+		return nil, fmt.Errorf("expected *appsv1.StatefulSet, got %T", obj)
 	}
 
 	controllerRevisionList, podList, err := ListControllerRevisionsAndPods(ctx, d.Client, statefulSet.Namespace, statefulSet.Spec.Selector)

--- a/pkg/history/statefulset_test.go
+++ b/pkg/history/statefulset_test.go
@@ -105,19 +105,13 @@ var _ = Describe("StatefulSetHistory", func() {
 			}
 		})
 
-		It("should fail if the StatefulSet doesn't exist", func() {
-			revs, err := history.ListRevisions(ctx, client.ObjectKey{Name: "non-existing"})
-			Expect(err).To(beNotFoundError())
-			Expect(revs).To(BeNil())
-		})
-
 		It("should return an empty list if there are no ControllerRevisions", func() {
 			statefulSet.ResourceVersion = ""
 			statefulSet.UID = ""
 			statefulSet.Namespace = "other"
 			Expect(fakeClient.Create(ctx, statefulSet)).To(Succeed())
 
-			revs, err := history.ListRevisions(ctx, client.ObjectKeyFromObject(statefulSet))
+			revs, err := history.ListRevisions(ctx, statefulSet)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(revs).To(BeEmpty())
 		})
@@ -142,7 +136,7 @@ var _ = Describe("StatefulSetHistory", func() {
 			helper.SetPodCondition(pod, corev1.PodReady, corev1.ConditionTrue)
 			Expect(fakeClient.Create(context.Background(), pod)).To(Succeed())
 
-			revs, err := history.ListRevisions(ctx, client.ObjectKeyFromObject(statefulSet))
+			revs, err := history.ListRevisions(ctx, statefulSet)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(revs).To(HaveLen(2))
 

--- a/pkg/history/statefulset_test.go
+++ b/pkg/history/statefulset_test.go
@@ -150,6 +150,15 @@ var _ = Describe("StatefulSetHistory", func() {
 			Expect(revs[1].CurrentReplicas()).To(BeEquivalentTo(1))
 			Expect(revs[1].ReadyReplicas()).To(BeEquivalentTo(1))
 		})
+
+		It("should also work via ListRevisions shortcut", func() {
+			revs, err := ListRevisions(ctx, fakeClient, statefulSet)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(revs).To(HaveLen(2))
+
+			Expect(revs[0].Object()).To(Equal(controllerRevision1))
+			Expect(revs[1].Object()).To(Equal(controllerRevision3))
+		})
 	})
 
 	Describe("NewControllerRevisionForStatefulSet", func() {


### PR DESCRIPTION
This PR refactors the `history.History` interface and implementations to take a full `client.Object` instead of a `client.ObjectKey`.
With this, the `ListRevisions` function can spare the additional `GET` request for the object, that is already performed by the kubectl libraries.

Before:

```
$ k revisions get deploy nginx -v6
I0708 22:15:54.192892   90818 round_trippers.go:553] GET https://127.0.0.1:50594/apis/apps/v1/namespaces/default/deployments/nginx 200 OK in 5 milliseconds
I0708 22:15:54.194036   90818 round_trippers.go:553] GET https://127.0.0.1:50594/apis/apps/v1/namespaces/default/deployments/nginx 200 OK in 0 milliseconds
I0708 22:15:54.195177   90818 round_trippers.go:553] GET https://127.0.0.1:50594/apis/apps/v1/namespaces/default/replicasets?labelSelector=deployment%3Dnginx 200 OK in 1 milliseconds
NAME               REVISION   READY   AGE
nginx-77bdb74675   1          3/3     84m

$ k revisions get deploy -v6
I0708 22:16:02.772346   91043 round_trippers.go:553] GET https://127.0.0.1:50594/apis/apps/v1/namespaces/default/deployments 200 OK in 5 milliseconds
I0708 22:16:02.774134   91043 round_trippers.go:553] GET https://127.0.0.1:50594/apis/apps/v1/namespaces/default/deployments/nginx 200 OK in 1 milliseconds
I0708 22:16:02.775542   91043 round_trippers.go:553] GET https://127.0.0.1:50594/apis/apps/v1/namespaces/default/replicasets?labelSelector=deployment%3Dnginx 200 OK in 1 milliseconds
I0708 22:16:02.776539   91043 round_trippers.go:553] GET https://127.0.0.1:50594/apis/apps/v1/namespaces/default/deployments/nginx2 200 OK in 0 milliseconds
I0708 22:16:02.777557   91043 round_trippers.go:553] GET https://127.0.0.1:50594/apis/apps/v1/namespaces/default/replicasets?labelSelector=deployment%3Dnginx2 200 OK in 0 milliseconds
I0708 22:16:02.778471   91043 round_trippers.go:553] GET https://127.0.0.1:50594/apis/apps/v1/namespaces/default/deployments/nginx3 200 OK in 0 milliseconds
I0708 22:16:02.779407   91043 round_trippers.go:553] GET https://127.0.0.1:50594/apis/apps/v1/namespaces/default/replicasets?labelSelector=deployment%3Dnginx3 200 OK in 0 milliseconds
NAME                REVISION   READY   AGE
nginx-77bdb74675    1          3/3     84m
nginx2-754bbc4897   1          3/3     83m
nginx3-784ddc76db   1          3/3     83m
```

After:

```
$ k revisions get deploy nginx -v6
I0708 22:38:01.273952    5075 round_trippers.go:553] GET https://127.0.0.1:50594/apis/apps/v1/namespaces/default/deployments/nginx 200 OK in 5 milliseconds
I0708 22:38:01.276802    5075 round_trippers.go:553] GET https://127.0.0.1:50594/apis/apps/v1/namespaces/default/replicasets?labelSelector=deployment%3Dnginx 200 OK in 1 milliseconds
NAME               REVISION   READY   AGE
nginx-77bdb74675   1          3/3     106m

$ k revisions get deploy -v6
I0708 22:38:04.067928    5144 round_trippers.go:553] GET https://127.0.0.1:50594/apis/apps/v1/namespaces/default/deployments 200 OK in 5 milliseconds
I0708 22:38:04.070295    5144 round_trippers.go:553] GET https://127.0.0.1:50594/apis/apps/v1/namespaces/default/replicasets?labelSelector=deployment%3Dnginx 200 OK in 1 milliseconds
I0708 22:38:04.071345    5144 round_trippers.go:553] GET https://127.0.0.1:50594/apis/apps/v1/namespaces/default/replicasets?labelSelector=deployment%3Dnginx2 200 OK in 0 milliseconds
I0708 22:38:04.072561    5144 round_trippers.go:553] GET https://127.0.0.1:50594/apis/apps/v1/namespaces/default/replicasets?labelSelector=deployment%3Dnginx3 200 OK in 1 milliseconds
NAME                REVISION   READY   AGE
nginx-77bdb74675    1          3/3     106m
nginx2-754bbc4897   1          3/3     105m
nginx3-784ddc76db   1          3/3     105m
```
