### PR TITLE
Don't complain about missing revision for multiple targets

### DIFF
--- a/pkg/cmd/get/get.go
+++ b/pkg/cmd/get/get.go
@@ -160,7 +160,8 @@ func (o *Options) Run(ctx context.Context, f util.Factory, args []string) (err e
 		if err != nil {
 			return err
 		}
-		if len(revs) == 0 {
+		if len(revs) == 0 && singleItemImplied {
+			// if targeting multiple items, we don't complain about individual items not having any revisions
 			return fmt.Errorf("no revisions found for %s/%s", kindString, info.Name)
 		}
 
@@ -175,6 +176,10 @@ func (o *Options) Run(ctx context.Context, f util.Factory, args []string) (err e
 		} else {
 			allRevisions = append(allRevisions, revs...)
 		}
+	}
+
+	if len(allRevisions) == 0 {
+		return fmt.Errorf("no revisions found for %s", kindString)
 	}
 
 	return p.PrintObj(allRevisions, o.Out)

--- a/test/e2e/exec/exec.go
+++ b/test/e2e/exec/exec.go
@@ -23,6 +23,10 @@ func AddFlags() {
 
 func PrepareTestBinaries() {
 	if binaryPath != "" {
+		// ensure binary path exists
+		_, err := os.Stat(binaryPath)
+		Expect(err).NotTo(HaveOccurred())
+
 		logf.Log.Info("Using pre-built binary", "path", binaryPath)
 	} else {
 		By("Building kubectl-revisions binary")


### PR DESCRIPTION
`kubectl revisions get -A -l ...` frequently fails in the e2e test case `[It] should list revisions of label-selected resources in all namespaces` with the following output on stderr:

```
    [err] error: no revisions found for daemonset.apps/pause
```

The test case itself doesn't even create a workload object called `pause`, so it can only be a left-over from a previous test in another namespace.
When a test case finishes, the namespace is deleted and cleaned up asynchronously. Hence, the first list call for the workload object (e.g., `DaemonSet`) might still contain an object from a previous test, but the second list call for the revisions object (e.g., `ControllerRevision`) might not have a matching object for the workload object.

Generally, we can assume that this only happens in racy test environments and almost never in real scenarios.
Even if it happened in the real world, failing because of a half-terminated object doesn't seem correct.

Hence, this PR changes the logic of the `get` command to not complain about missing revisions for a single workload object when targeting multiple objects. 
If the `get` command can't find any revisions for all targeted workload objects, it still complains.

There is also a second commit that improves the deflaking workflow.