### PR TITLE
Add `kindest/node` digest and let renovate update it

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -28,6 +28,17 @@
         '# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s.+?_VERSION *[?:]?= *"?(?<currentValue>.+?)"?\\s',
       ],
     },
+    {
+      // custom manager for updating kind node image tag and digest
+      customType: "regex",
+      managerFilePatterns: [
+        "/^Makefile$/",
+      ],
+      matchStrings: [
+        "(?<depName>kindest/node):(?<currentValue>[^@]+)(?:@(?<currentDigest>[^\\s]+))?",
+      ],
+      datasourceTemplate: "docker",
+    },
   ],
   packageRules: [
     {

--- a/Makefile
+++ b/Makefile
@@ -121,15 +121,12 @@ install: ## Install the kubectl-revisions binary to $GOBIN.
 
 ##@ Test Setup
 
-# renovate: datasource=docker depName=kindest/node
-KIND_KUBERNETES_VERSION ?= v1.33.1
-
 KIND_KUBECONFIG := $(PROJECT_DIR)/hack/kind_kubeconfig.yaml
 kind-up kind-down: export KUBECONFIG = $(KIND_KUBECONFIG)
 
 .PHONY: kind-up
 kind-up: $(KIND) $(KUBECTL) ## Launch a kind cluster for local development and testing.
-	$(KIND) create cluster --name revisions --config hack/kind-config.yaml --image kindest/node:$(KIND_KUBERNETES_VERSION)
+	$(KIND) create cluster --name revisions --config hack/kind-config.yaml --image kindest/node:v1.33.1@sha256:050072256b9a903bd914c0b2866828150cb229cea0efe5892e2b644d5dd3b34f
 	# workaround https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files
 	$(KUBECTL) get nodes -o name | cut -d/ -f2 | xargs -I {} docker exec {} sh -c "sysctl fs.inotify.max_user_instances=8192"
 	# run `export KUBECONFIG=$$PWD/hack/kind_kubeconfig.yaml` to target the created kind cluster.


### PR DESCRIPTION
The kind release notes recommend pinning the `kindest/node` digest. This PR does so and teaches renovate to update it.